### PR TITLE
jsonb, null, and md5 password auth

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -293,6 +293,7 @@ export function readRowData(
                         return buffer.toString(encoding, start, end);
                     case DataType.Bytea:
                         return buffer.slice(start, end);
+                    case DataType.Jsonb:
                     case DataType.Json:
                         const document = buffer.toString(encoding, start, end);
                         if (document) {
@@ -553,6 +554,14 @@ export class Writer {
                     };
                     break;
                 };
+                case DataType.Jsonb:
+                  const body = JSON.stringify(value);
+                  add(SegmentType.Int8, 0x01);
+                  size = 1 + add(
+                    SegmentType.Buffer,
+                    makeBuffer(body, this.encoding)
+                  );
+                  break;
                 case DataType.Json: {
                     const body = JSON.stringify(value);
                     size = add(
@@ -663,6 +672,7 @@ export class Writer {
                     return (value instanceof Date) ?
                         dateToStringUTC(value, true) :
                         value.toString();
+                case DataType.Jsonb:
                 case DataType.Json:
                     return JSON.stringify(value);
                 default: {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -218,7 +218,7 @@ export function readRowData(
     while (i < columns) {
         const length = buffer.readInt32BE(dataColumnOffset);
         const start = dataColumnOffset + 4;
-        const end = start + length;
+        const end = start + (length >= 0 ? length : 0);
 
         dataColumnOffset = end;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,14 @@
+import { createHash } from 'crypto';
+
 export function sum(...nums: number[]): number {
-    return nums.reduce((a, b) => a + b, 0);
-};
+  return nums.reduce((a, b) => a + b, 0);
+}
+
+export type HashData = string | Buffer | NodeJS.TypedArray | DataView;
+
+export function md5(...data: HashData[]): string {
+  return data
+    .reduce((hash, d) => hash.update(d),
+      createHash('md5'))
+    .digest('hex');
+}

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,3 +1,4 @@
+import { md5 } from '../src/utils';
 import { testWithClient } from './helper';
 import { Query } from '../src/query';
 import { Result } from '../src/client';
@@ -314,4 +315,19 @@ describe('Query', () => {
     testSelect(TestQuery.Array, 5, false);
     testSelect(TestQuery.Array, 1, true);
     testSelect(TestQuery.Array, 5, true);
+});
+
+test("",()=>{
+  const salt = new Uint8Array(4);
+  salt[0] = 46;
+  salt[1] = 226;
+  salt[2] = 27;
+  salt[3] = 67;
+  const shadow = md5('passwordflynotes');
+  const transfer = md5(
+    shadow,
+    salt);
+  console.log(shadow);
+  console.log(transfer);
+  console.log(md5(transfer));
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -15,6 +15,7 @@ function getComparisonQueryFor(dataType: DataType, expression: string) {
     switch (dataType) {
         case DataType.ArrayJson:
             return `select ($1)::jsonb[] <@ (${expression})::jsonb[]`;
+        case DataType.Jsonb:
         case DataType.Json:
             return `select ($1)::jsonb <@ (${expression})::jsonb`;
         case DataType.Point:
@@ -233,6 +234,10 @@ describe('Types', () => {
         [utc_date(1999, 11, 31, 23, 59, 59)]);
     testType<JsonMap>(
         DataType.Json,
+        '\'{"foo": "bar"}\'::json',
+        { 'foo': 'bar' });
+    testType<JsonMap>(
+        DataType.Jsonb,
         '\'{"foo": "bar"}\'::json',
         { 'foo': 'bar' });
     testType<JsonMap[]>(

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -6,7 +6,7 @@ import {
     Point,
     Value,
     DataFormat
-} from '../src/types';
+} from '../src';
 
 const infinity = Number('Infinity');
 
@@ -33,7 +33,9 @@ function testType<T extends Value>(
     const testParam = (format: DataFormat) => {
         testWithClient('Param', async (client) => {
             expect.assertions(3);
-            const query = getComparisonQueryFor(dataType, expression);
+            const query = expected !== null
+              ? getComparisonQueryFor(dataType, expression)
+              : 'select $1 is null';
             await client.query(
                 (expected !== null) ? query + ' where $1 is not null' : query,
                 [expected], [dataType], format)
@@ -245,4 +247,10 @@ describe('Types', () => {
         'ARRAY[\'{"foo": "bar"}\'::json]',
         [{ 'foo': 'bar' }],
         true);
+    // Test nulls
+    testType<string|null>(
+        DataType.Uuid,
+        'null',
+        null
+    );
 });


### PR DESCRIPTION
Just being lazy with the single PR Malthe- let me know if you want me to split it.

Tested `AuthenticationMD5Password` authentication with a real app, but wrote no tests. I think you need to muck around with `pg_hba.conf` to switch it on, and it's nice that the test suite as it stands runs against any old postgres. If you can think of a nice way to test it, I'm happy to implement it.

After sending password in `client.ts`, I tried calling `this.flush()` but that does nothing because `this.ready` is false until authentication is complete, so it short circuits. Instead I call `this.writer.send()` directly. 

https://github.com/malthe/ts-postgres/compare/master...savagematt:master#diff-3cafb86a5b0a9d0916a7fed543a1fb53R718

This works, but I don't set `this.mustDrain = true`. Should I be doing that?

Is it the case that `AuthenticationCleartextPassword` would cause `connect()` to hang for the same reason (`AuthenticationOk` is never received, so connect is never emitted)?
 