### PR TITLE
Added details of database error to thrown error message

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -732,6 +732,7 @@ export class Client {
         let level: DatabaseError['level'] | null = null;
         let code: DatabaseError['code'] | null = null;
         let message: DatabaseError['message'] | null = null;
+        let details: string | null = null;
 
         const length = buffer.length;
         let offset = 0;
@@ -756,6 +757,10 @@ export class Client {
                     code = value as DatabaseError['code'];
                     break;
                 }
+                case 0x44: {
+                    details = value;
+                    break;
+                }
                 case 0x4d: {
                     message = value;
                     break;
@@ -768,7 +773,7 @@ export class Client {
         }
 
         if (level && code && message) {
-            return new DatabaseError(level, code, message);
+            return new DatabaseError(level, code, details ? `${message}: ${details}` : message);
         }
 
         throw new Error('Unable to parse error message.');


### PR DESCRIPTION
Currently, the details of an error are not displayed in the error message, although the server provides this information.
This PR changes that accordingly.
Instead of the message: `insert or update on table "my_sub_table" violates foreign key constraint "id_fk"`, the following would now be displayed: `insert or update on table "my_sub_table" violates foreign key constraint "id_fk": Key (id)=(99999) is not present in table "my_main_table"`