### PR TITLE
Upgrade to latest action versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        node-version: ['14.x', '16.x', '18.x']
+        node-version: ['16.x', '18.x']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Run tests


### PR DESCRIPTION
See https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/.