### PR TITLE
Enable SSL in PostgreSQL during CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  PGDATADIR: /var/lib/postgresql/data
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,6 +23,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
@@ -28,13 +32,44 @@ jobs:
       matrix:
         node-version: ['18.x', '20.x']
     steps:
+      - run: |
+          function set() {
+              docker exec ${{ job.services.postgres.id }} sh -c "echo $1=\'$2\' >> $PGDATADIR/postgresql.conf"
+          }
+          set ssl on
+          set ssl_cert_file /etc/ssl/certs/ssl-cert-snakeoil.pem
+          set ssl_key_file /etc/ssl/private/ssl-cert-snakeoil.key
+          set fsync off
+          set full_page_writes off
+          set synchronous_commit off
+          docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Run tests
-        run: npm run test:prod && npm run build
+        run: npm run test:prod
         env:
           PGSSLMODE: disable
+          PGPORT: ${{ job.services.postgres.ports[5432] }}
+          PGUSER: postgres
+          PGPASSWORD: postgres
+      - name: Run tests (SSL)
+        run: |
+          docker cp ${{ job.services.postgres.id }}:/etc/ssl/certs/ssl-cert-snakeoil.pem ./
+          npm run test:prod || exit 1
+          npm run build
+          cat <<- EOF > test.mjs
+          import { Client } from './dist/src/index.js';
+          const client = new Client();
+          const secured = await client.connect();
+          console.log(secured);
+          await client.end();
+          EOF
+          set -o pipefail
+          node test.mjs | tee /dev/stderr | grep -q true
+        env:
+          NODE_EXTRA_CA_CERTS: ssl-cert-snakeoil.pem
+          PGSSLMODE: require
           PGPORT: ${{ job.services.postgres.ports[5432] }}
           PGUSER: postgres
           PGPASSWORD: postgres

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,16 +73,3 @@ jobs:
           PGPORT: ${{ job.services.postgres.ports[5432] }}
           PGUSER: postgres
           PGPASSWORD: postgres
-      - name: Check SSL
-        run: |
-          exec node <<EOF
-          import { Client } from 'ts-postgres';
-          const client = new Client();
-          const secured = await client.connect();
-          console.log("Secured: " + secured);
-          EOF
-        env:
-          PGSSLMODE: require
-          PGPORT: ${{ job.services.postgres.ports[5432] }}
-          PGUSER: postgres
-          PGPASSWORD: postgres

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,3 +73,16 @@ jobs:
           PGPORT: ${{ job.services.postgres.ports[5432] }}
           PGUSER: postgres
           PGPASSWORD: postgres
+      - name: Check SSL
+        run: |
+          exec node <<EOF
+          import { Client } from 'ts-postgres';
+          const client = new Client();
+          const secured = await client.connect();
+          console.log("Secured: " + secured);
+          EOF
+        env:
+          PGSSLMODE: require
+          PGPORT: ${{ job.services.postgres.ports[5432] }}
+          PGUSER: postgres
+          PGPASSWORD: postgres

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     services:
       postgres:
         image: postgres

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 In next release ...
 
+- The "verify-ca" SSL mode has been removed, favoring "require"; in addition, both
+  "prefer" and "require" imply certificate verification. To use a self-signed
+  certificate, use for example the `NODE_EXTRA_CA_CERTS` environment variable
+  to provide the public key to the runtime as a trusted certificate.
+
 - Database name now implicitly defaults to the user name.
 
 - Add additional client connection configuration options.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 In next release ...
 
+- The `connect` method now returns a boolean status of whether the
+  connection is encrypted.
+
 - The "verify-ca" SSL mode has been removed, favoring "require"; in addition, both
   "prefer" and "require" imply certificate verification. To use a self-signed
   certificate, use for example the `NODE_EXTRA_CA_CERTS` environment variable

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
         "coveragePathIgnorePatterns": [
             "/node_modules/",
             "/test/",
+            "/src/defaults.ts",
+            "/src/index.ts",
             "/src/logging.ts",
             "/src/queue.ts",
             "/src/utils.ts"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
             "/src/index.ts",
             "/src/logging.ts",
             "/src/queue.ts",
+            "/src/sasl.ts",
             "/src/utils.ts"
         ],
         "coverageThreshold": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,7 +11,7 @@ import { postgresqlErrorCodes } from './errors';
 import { Queue } from './queue';
 import { Query } from './query';
 
-import { ConnectionOptions, connect as tls, createSecureContext } from 'tls';
+import { ConnectionOptions, TLSSocket, connect as tls, createSecureContext } from 'tls';
 
 import {
     DataHandler,
@@ -70,19 +70,14 @@ export interface DataTypeError {
     value: Value
 }
 
-export const enum SSLMode {
+export enum SSLMode {
     Disable = 'disable',
     Prefer = 'prefer',
     Require = 'require',
-    VerifyCA = 'verify-ca'
 }
 
 export interface SSL {
-    mode?: (
-        SSLMode.Prefer |
-        SSLMode.Require |
-        SSLMode.VerifyCA
-    ),
+    mode: (SSLMode.Prefer | SSLMode.Require),
     options?: ConnectionOptions,
 }
 
@@ -206,7 +201,7 @@ export class Client {
     private nextPreparedStatementId = 0;
     private activeDataHandlerInfo: RowDataHandlerInfo | null = null;
 
-    public closed = false;
+    public closed = true;
     public processId: number | null = null;
     public secretKey: number | null = null;
     public transactionStatus: TransactionStatus | null = null;
@@ -216,7 +211,7 @@ export class Client {
         this.writer = new Writer(this.encoding);
 
         this.stream.on('close', () => {
-            this.connected = false;
+            this.closed = true;
             this.events.end.emit();
         });
 
@@ -248,18 +243,21 @@ export class Client {
         });
 
         this.stream.on('finish', () => {
-            this.closed = true;
+            this.connected = false;
         });
     }
 
     private startup() {
         const writer = new Writer(this.encoding);
 
-        const ssl =
-            defaults.sslMode === SSLMode.Disable ? SSLMode.Disable :
-                this.config.ssl || {
-                    mode: defaults.sslMode,
-                } as SSL;
+        if (defaults.sslMode && Object.values(SSLMode).indexOf(defaults.sslMode as SSLMode) < 0) {
+            throw new Error("Invalid SSL mode: " + defaults.sslMode);
+        }
+
+        const ssl = this.config.ssl ??
+            (defaults.sslMode as SSLMode || SSLMode.Disable) === SSLMode.Disable
+                ? SSLMode.Disable
+                : ({ mode: SSLMode.Prefer, options: undefined });
 
         const settings = {
             user: this.config.user || defaults.user,
@@ -279,7 +277,10 @@ export class Client {
         if (ssl !== SSLMode.Disable) {
             writer.startupSSL();
 
-            const abort = (error: Connect) => {
+            const abort = (error: Error) => {
+                if (!this.handleError(error)) {
+                    throw new Error("Internal error occurred while establishing connection");
+                }
                 this.events.connect.emit(error);
                 this.end();
             }
@@ -291,10 +292,6 @@ export class Client {
                 this.sendUsing(writer);
             }
 
-            const required =
-                ssl.mode === SSLMode.Require ||
-                ssl.mode === SSLMode.VerifyCA;
-
             this.stream.once('data', (buffer: Buffer) => {
                 const code = buffer.readInt8(0);
                 switch (code) {
@@ -304,7 +301,7 @@ export class Client {
 
                     // Server does not support SSL connections.
                     case SSLResponseCode.NotSupported:
-                        if (required) {
+                        if (ssl.mode === SSLMode.Require) {
                             abort(
                                 new Error(
                                     'Server does not support SSL connections'
@@ -330,27 +327,17 @@ export class Client {
                     undefined;
 
                 const options = {
-                    checkServerIdentity: ssl.options ?
-                        ssl.options.checkServerIdentity :
-                        undefined,
                     socket: this.stream,
-                    secureContext: context
+                    secureContext: context,
+                    ...(ssl.options ?? {})
                 };
 
-                const verify = ssl.mode == SSLMode.VerifyCA;
-
-                const stream = tls(
+                const stream: TLSSocket = tls(
                     options,
-                    () => {
-                        if (verify && !stream.authorized) {
-                            abort(stream.authorizationError)
-                        } else {
-                            startup(stream);
-                        }
-                    }
+                    () => startup(stream)
                 );
 
-                stream.on('error', (error) => {
+                stream.on('error', (error: Error) => {
                     abort(error);
                 });
             });

--- a/src/client.ts
+++ b/src/client.ts
@@ -764,6 +764,7 @@ export class Client {
     }
 
     private sendUsing(writer: Writer) {
+        if (this.ending) return;
         if (!this.stream.writable) throw new Error('Stream not writable');
         const full = writer.send(this.stream);
         if (full !== undefined) {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -2,7 +2,6 @@ function secToMsec(value?: number) {
     if (typeof value === "number" && !isNaN(value)) {
         return value * 1000;
     }
-    return undefined;
 }
 
 export const host = process.env.PGHOST || 'localhost';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -10,15 +10,23 @@ export function testWithClient(name: string, fn: Test, timeout?: number) {
     });
     client.on('notice', console.log);
     test(name, async () => {
-        const p = fn(client);
-        await client.connect();
-        let closed = false;
+        let closed = true;
+        let connected = false;
+        client.on('connect', () => { closed = false; });
         client.on('end', () => { closed = true; });
+        const p2 = client.connect();
+        const p1 = fn(client);
         try {
-            await p;
+            await p1;
+            await p2;
+            connected = true;
         } finally {
+            if (!connected) {
+                await p2;
+            }
             if (!closed) {
                 await client.end();
+                if (!closed) throw new Error("Expected client close event");
                 if (!client.closed) throw new Error("Expected client to be closed");
             }
         }


### PR DESCRIPTION
This change simplifies the configuration of SSL, now using a mode selection of either _disabled_, _prefer_, or _require_.

Previously, there was both "require" and "verify-ca", analogous to the [libpq library options](https://www.postgresql.org/docs/current/libpq-ssl.html), but implemented somewhat incorrectly.

The new options are much more clear and secure. It's no longer possible to connect using encryption without verifying the certificate. Instead, using for example `NODE_EXTRA_CA_CERTS` to trust a self-signed certificate is encouraged.