### PR TITLE
Optimize "get" method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 In next release ...
 
+- Use lookup table to optimize `get` method.
+
 - The `connect` method now returns a boolean status of whether the
   connection is encrypted.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,7 @@ export type ResultIterator = _ResultIterator<Value>;
 
 export type ResultRow = _ResultRow<Value>;
 
-export type Connect = (Error | string | null);
+export type Connect = Error | null;
 
 export type End = void;
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -8,22 +8,25 @@ type ResultHandler = (resolve: Resolver) => void;
 type Callback<T> = (item: T) => void;
 
 export class ResultRow<T> {
-    private readonly length: number;
+    private readonly lookup: {[name: string]: number};
 
     constructor(public readonly names: string[], public readonly data: T[]) {
-        this.length = names.length;
+        const lookup: {[name: string]: number} = {};
+        let i = 0;
+        for (const name of names) {
+            lookup[name] = i;
+            i++;
+        }
+        this.lookup = lookup;
     }
 
     [Symbol.iterator](): Iterator<T> {
-	return this.data[Symbol.iterator]();
+        return this.data[Symbol.iterator]();
     }
 
     get(name: string): T | undefined {
-        for (let i = 0; i < this.length; i++) {
-            if (this.names[i] === name) {
-                return this.data[i];
-            }
-        }
+        const i = this.lookup[name];
+        return this.data[i];
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
       "allowSyntheticDefaultImports": true,
       "experimentalDecorators": true,
       "emitDecoratorMetadata": true,
+      "noImplicitAny": true,
       "noUnusedParameters": true,
       "noUnusedLocals": true,
       "declarationDir": "dist",


### PR DESCRIPTION
Using a lookup table here has proven significantly faster in microbenchmarks.