### PR TITLE
Column name transformation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+In the next release ...
+
+- The `query` method now accepts a `QueryParameter` object as the
+  first value, in addition to the query string, making it easier to
+  make a query with additional configuration.
+
 1.6.0 (2023-12-13)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 In the next release ...
 
+- The query options now supports an optional `transform` parameter which takes
+  a column name input, allowing the transformation of column names into for
+  example camelcase.
+
 - The `query` method now accepts a `QueryParameter` object as the
   first value, in addition to the query string, making it easier to
   make a query with additional configuration.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,13 @@ The copy commands are not supported.
    pool.use(...)
    ```
 
+2. _How do I convert column names to camelcase?_ Use the `transform` option:
+
+   ```typescript
+   const camelcase = (s: string) => s.replace(/(_\w)/g, k => k[1].toUpperCase());
+   const result = client.query({text: ..., transform: camelcase})
+   ```
+
 ## Benchmarking
 
 Use the following environment variable to run tests in "benchmark" mode.

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,7 +9,7 @@ import * as logger from './logging';
 
 import { postgresqlErrorCodes } from './errors';
 import { Queue } from './queue';
-import { Query } from './query';
+import { Query, QueryParameter } from './query';
 
 import { ConnectionOptions, TLSSocket, connect as tls, createSecureContext } from 'tls';
 
@@ -588,23 +588,35 @@ export class Client {
             });
     }
 
+    /**
+     * Send a query to the database.
+     *
+     * The query string is given as the first argument, or pass a {@link QueryParameter}
+     * object which provides more control.
+     *
+     * @param text - The query string, or pass a {@link QueryParameter}
+     *     object which provides more control (including streaming values into a socket).
+     * @param values - The query parameters, corresponding to $1, $2, etc.
+     * @param types - Allows making the database native type explicit for some or all
+     *     columns.
+     * @param format - Whether column data should be transferred using text or binary mode.
+     * @param streams - A mapping from column name to a socket, e.g. an open file.
+     * @returns A promise for the query results.
+     */
     query<T = ResultRecord>(
-        text: string,
+        text: QueryParameter | string,
         values?: any[],
         types?: DataType[],
         format?: DataFormat | DataFormat[],
         streams?: Record<string, Writable>):
         ResultIterator<T> {
-        const query =
-            (typeof text === 'string') ?
-                new Query(
-                    text,
-                    values, {
-                    types: types,
-                    format: format,
-                    streams: streams,
-                }) :
-                text;
+        const query = new Query(
+            text,
+            values, {
+            types: types,
+            format: format,
+            streams: streams,
+        });
         return this.execute<T>(query);
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -663,10 +663,10 @@ export class Client {
         const text = query.text;
         const values = query.values || [];
         const options = query.options;
-        const format = options ? options.format : undefined;
-        const types = options ? options.types : undefined;
-        const streams = options ? options.streams : undefined;
-        const portal = (options ? options.portal : undefined) || '';
+        const format = options?.format;
+        const types = options?.types;
+        const streams = options?.streams;
+        const portal = options?.portal || '';
         const result = makeResult<T>();
 
         const descriptionHandler = (description: RowDescription) => {
@@ -679,7 +679,7 @@ export class Client {
         };
 
         if (values && values.length) {
-            const name = (options ? options.name : undefined) || (
+            const name = (options?.name) || (
                 (this.config.preparedStatementPrefix ||
                     defaults.preparedStatementPrefix) + (
                     this.nextPreparedStatementId++

--- a/src/query.ts
+++ b/src/query.ts
@@ -5,15 +5,30 @@ import {
 } from './types';
 
 export interface QueryOptions {
+    /** The query name. */
     readonly name: string;
+    /** Whether to use the default portal (i.e. unnamed) or provide a name. */
     readonly portal: string;
+    /** Allows making the database native type explicit for some or all columns. */
     readonly types: DataType[];
+    /** Whether column data should be transferred using text or binary mode. */
     readonly format: DataFormat | DataFormat[];
+    /** A mapping from column name to a socket, e.g. an open file. */
     readonly streams: Record<string, Writable>;
+    /** Allows the transformation of column names as returned by the database. */
+    readonly transform: (name: string) => string;
 }
 
+/**
+ * A query parameter can be used in place of a query text as the first argument
+ * to the {@link Client.query} method.
+ * @interface
+ */
 export type QueryParameter = Partial<QueryOptions> & { text: string };
 
+/**
+ * A complete query object, ready to send to the database.
+ */
 export class Query {
     public readonly text: string;
     public readonly values?: any[];

--- a/src/query.ts
+++ b/src/query.ts
@@ -12,10 +12,24 @@ export interface QueryOptions {
     readonly streams: Record<string, Writable>;
 }
 
+export type QueryParameter = Partial<QueryOptions> & { text: string };
+
 export class Query {
+    public readonly text: string;
+    public readonly values?: any[];
+    public readonly options?: Partial<QueryOptions>;
+
     constructor(
-        public readonly text: string,
-        public readonly values?: any[],
-        public readonly options?: Partial<QueryOptions>
-    ) { }
+        text: QueryParameter | string,
+        values?: any[],
+        options?: Partial<QueryOptions>
+    ) {
+        this.values = values;
+        this.options = options;
+        if (typeof text === 'string') {
+            this.text = text;
+        } else {
+            ({ text: this.text, ...this.options } = {...this.options, ...text});
+        }
+    }
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -209,7 +209,7 @@ export type NameHandler = Callback<string[]>;
 
 ResultIterator.prototype.constructor = Promise
 
-export function makeResult<T>() {
+export function makeResult<T>(transform?: (name: string) => string) {
     let dataHandler: DataHandler | null = null;
 
     const names: string[] = [];
@@ -232,6 +232,9 @@ export function makeResult<T>() {
 
     const nameHandler = (ns: string[]) => {
         names.length = 0;
+        if (transform) {
+            ns = ns.map(transform);
+        }
         names.push(...ns);
     }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -7,7 +7,7 @@ type Callback<T> = (item: T) => void;
 type ResultHandler = (resolve: Callback<Resolution>, reject: Callback<Error | DatabaseError>) => void;
 
 /** The default result type, used if no generic type parameter is specified. */
-export type ResultRecord = Record<string, any>
+export type ResultRecord<T = any> = Record<string, T>;
 
 
 function makeRecord<T>(names: string[], data: ReadonlyArray<any>): T {


### PR DESCRIPTION
Often times, SQL identifiers are snake case whereas JavaScript tends to use camelcase. This is just one example where a column name transformation can be useful to avoid tedious (and ugly!) property renaming.