### PR TITLE
Remove 'execute' method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,12 @@
 In the next release ...
 
+- The `execute` method has been removed.
+
 - The query options now supports an optional `transform` parameter which takes
   a column name input, allowing the transformation of column names into for
   example camelcase.
 
-- The `query` method now accepts a `QueryParameter` object as the
+- The `query` method now accepts a `Query` object as the
   first value, in addition to the query string, making it easier to
   make a query with additional configuration.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from './client';
+export { Client, PreparedStatement } from './client';
 export {
     DataFormat,
     DataType,

--- a/src/query.ts
+++ b/src/query.ts
@@ -24,27 +24,4 @@ export interface QueryOptions {
  * to the {@link Client.query} method.
  * @interface
  */
-export type QueryParameter = Partial<QueryOptions> & { text: string };
-
-/**
- * A complete query object, ready to send to the database.
- */
-export class Query {
-    public readonly text: string;
-    public readonly values?: any[];
-    public readonly options?: Partial<QueryOptions>;
-
-    constructor(
-        text: QueryParameter | string,
-        values?: any[],
-        options?: Partial<QueryOptions>
-    ) {
-        this.values = values;
-        this.options = options;
-        if (typeof text === 'string') {
-            this.text = text;
-        } else {
-            ({ text: this.text, ...this.options } = {...this.options, ...text});
-        }
-    }
-}
+export type Query = Partial<QueryOptions> & { text: string };


### PR DESCRIPTION
The functionality has largely been replaced by additional flexibility of the `query` method.