### PR TITLE
Remove 'execute' method; simplify 'query' and 'prepare' methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,16 @@ In the next release ...
 
 - The `execute` method has been removed.
 
-- The query options now supports an optional `transform` parameter which takes
-  a column name input, allowing the transformation of column names into for
-  example camelcase.
+- The querying options now include an optional `transform` property which must be
+  a function which takes a column name input, allowing the transformation of column
+  names into for example _camel-case_.
 
-- The `query` method now accepts a `Query` object as the
-  first value, in addition to the query string, making it easier to
-  make a query with additional configuration.
+- The `query` method now accepts a `Query` object as the first argument in
+  addition to a string argument, but no longer accepts any additional arguments
+  after `values`. The query options must now be provided using the query argument
+  instead.
+
+  The same change has been made to `prepare`.
 
 1.6.0 (2023-12-13)
 ------------------

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -35,9 +35,11 @@ function testType<T>(
             const query = expected !== null
                 ? getComparisonQueryFor(dataType, expression)
                 : 'select $1 is null';
-            await client.query(
-                (expected !== null) ? query + ' where $1 is not null' : query,
-                [expected], [dataType], format)
+            await client.query({
+                text: expected !== null ? query + ' where $1 is not null' : query,
+                types: [dataType],
+                format
+            }, [expected])
                 .then(
                     (result) => {
                         const rows = result.rows;
@@ -52,7 +54,7 @@ function testType<T>(
         testWithClient('Value', async (client) => {
             expect.assertions(3);
             const query = 'select ' + expression;
-            await client.query(query, [], [], format).then(
+            await client.query({text: query, format}, []).then(
                 (result) => {
                     const rows = result.rows;
                     expect(rows.length).toEqual(1);


### PR DESCRIPTION
The `query` method now accepts a `Query` object as the first argument in addition to a string argument, but no longer accepts any additional arguments after `values`. The query options must now be provided using the query argument instead.

Finally, the `execute` method has been removed.