### PR TITLE
Set up redirects for example code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,22 @@ jobs:
           echo '{"type": "module"}' > dist/module/package.json
           mkdir dest
           npm pack --pack-destination=dest
-      - name: Docs
+      - name: Typedoc
         run: npx typedoc
+      - name: Redirects
+        run: |
+          ref=${GITHUB_BASE_REF:-master}
+          url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/$ref
+          find examples -mindepth 1 -maxdepth 1 -exec sh -c "
+          mkdir -p docs/{}
+          cat << EOF > docs/{}/index.html
+          <\!DOCTYPE html>
+          <meta charset='utf-8'>
+          <title>Redirecting to $url/{}</title>
+          <meta http-equiv='refresh' content='0; URL=$url/{}'>
+          <link rel='canonical' href='$url/{}'>
+          EOF
+          " \;
       - uses: actions/upload-pages-artifact@v2
         with:
           path: ./docs


### PR DESCRIPTION
In the generated docs, relative links to examples should be set up with redirects back to the repository.