### PR TITLE
Connect function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 In next release ...
 
-- 
+- The `connect` function is now used to create a client, already
+  connected when the promise returns. The `Client` symbol is now a
+  type instead of a value.
 
 1.9.0 (2024-01-23)
 ------------------

--- a/README.md
+++ b/README.md
@@ -33,14 +33,13 @@ See the [documentation](https://malthe.github.io/ts-postgres/) for a complete re
 The client uses an async/await-based programming model.
 
 ```typescript
-import { Client } from 'ts-postgres';
+import { connect } from 'ts-postgres';
 
 interface Greeting {
     message: string;
 }
 
-const client = new Client();
-await client.connect();
+const client = await connect();
 
 try {
     // The query method is generic on the result row.
@@ -72,7 +71,7 @@ The client constructor takes an optional
 For example, to connect to a remote host use the *host* configuration key:
 
 ```typescript
-const client = new Client({"host": <hostname>});
+const client = await connect({"host": <hostname>});
 ```
 
 The following table lists the various configuration options and their
@@ -257,7 +256,7 @@ The copy commands are not supported.
    notifications, filtering out the relevant channels.
 
    ```typescript
-   import { Notification } from 'ts-postgres';
+   import type { Notification } from 'ts-postgres';
 
    const channel = 'test';
    client.on('notification', (message: Notification) => {

--- a/examples/connect/main.cjs
+++ b/examples/connect/main.cjs
@@ -1,8 +1,7 @@
-const { Client } = require('ts-postgres');
-const client = new Client();
-module.exports = client.connect().then(
-  (info) => {
-    console.log("Encrypted: " + info.encrypted);
+const { connect } = require('ts-postgres');
+module.exports = connect().then(
+  (client) => {
+    console.log("Encrypted: " + client.encrypted);
     return client.end();
   }
 );

--- a/examples/connect/main.mts
+++ b/examples/connect/main.mts
@@ -1,5 +1,4 @@
-import { Client } from 'ts-postgres';
-const client = new Client();
-const info = await client.connect();
-console.log("Encrypted: " + info.encrypted);
+import { connect } from 'ts-postgres';
+const client = await connect();
+console.log("Encrypted: " + client.encrypted);
 await client.end();

--- a/examples/connect/package.json
+++ b/examples/connect/package.json
@@ -4,6 +4,6 @@
         "typescript": "^4.8"
     },
     "dependencies": {
-        "ts-postgres": "^1.8"
+        "ts-postgres": "^2.0"
     }
 }

--- a/examples/generic-pool/main.mts
+++ b/examples/generic-pool/main.mts
@@ -1,10 +1,10 @@
-import { Client } from 'ts-postgres';
+import { connect } from 'ts-postgres';
+import type { Client } from 'ts-postgres';
 import { createPool } from 'generic-pool';
 
 const pool = createPool({
     create: async () => {
-        const client = new Client();
-        await client.connect();
+        const client = await connect();
         client.on('error', console.log);
         return client;
     },

--- a/examples/generic-pool/package.json
+++ b/examples/generic-pool/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "generic-pool": "^3.9.0",
-        "ts-postgres": "^1.9"
+        "ts-postgres": "^2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-postgres",
     "type": "module",
-    "version": "1.9.1-dev",
+    "version": "2.0.0-dev",
     "description": "PostgreSQL client in TypeScript",
     "declaration": true,
     "keywords": [

--- a/src/client.ts
+++ b/src/client.ts
@@ -159,12 +159,7 @@ interface PreFlightQueue {
 
 const DEFAULTS = new Defaults(env as unknown as Environment);
 
-/** A database client, opening a single connection to the database.
- *
- * @remarks
- * You must open the connection using {@link connect}, otherwise no query will be processed.
- */
-export class Client {
+export class ClientImpl {
     private readonly events = {
         connect: new TypedEvent<Connect>(),
         end: new TypedEvent<End>(),
@@ -404,14 +399,7 @@ export class Client {
         });
     }
 
-    /** Connect to the database.
-     *
-     * @remarks
-     * Don't forget to close the connection using {@link end} before exiting.
-     *
-     * @returns The connection information.
-     */
-    connect(host?: string, port?: number, connectionTimeout?: number): Promise<ConnectionInfo> {
+    connect(): Promise<ConnectionInfo> {
         if (this.connecting) {
             throw new Error('Already connecting');
         }
@@ -421,7 +409,7 @@ export class Client {
         }
         this.connecting = true;
 
-        const timeout = connectionTimeout ?? this.config.connectionTimeout ?? DEFAULTS.connectionTimeout;
+        const timeout = this.config.connectionTimeout ?? DEFAULTS.connectionTimeout;
 
         let p = this.events.connect.once().then((error: Connect) => {
             if (error) {
@@ -435,8 +423,8 @@ export class Client {
             }
         });
 
-        host = host ?? this.config.host ?? DEFAULTS.host;
-        port = port ?? this.config.port ?? DEFAULTS.port;
+        const host = this.config.host ?? DEFAULTS.host;
+        const port = this.config.port ?? DEFAULTS.port;
 
         if (host.indexOf('/') === 0) {
             this.stream.connect(host + '/.s.PGSQL.' + port);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,16 @@
-export {
-    Client,
+import {
+    ClientImpl,
+    SSLMode,
 } from './client.js';
+import type { Configuration, ConnectionInfo } from './client.js';
 export type {
+    Callback,
     ClientNotice,
-    Configuration,
-    ConnectionInfo,
     DataTypeError,
     Notification,
     PreparedStatement,
     SSL,
-    SSLMode,
 } from './client.js';
-export {
-    DataFormat,
-    DataType,
-} from './types.js';
 export type {
     BufferEncoding,
     Point,
@@ -38,3 +34,36 @@ export type {
     ErrorLevel,
     TransactionStatus,
 } from './protocol.js';
+
+export type {
+    Configuration,
+};
+
+export {
+    DataFormat,
+    DataType,
+} from './types.js';
+
+export { SSLMode };
+
+interface _Client extends ClientImpl { }
+
+/** A database client, encapsulating a single connection to the database.
+ *
+ * @interface
+ */
+export type Client = Omit<_Client, 'connect'> & ConnectionInfo;
+
+/** Connect to the database.
+ *
+ * @remarks
+ * You must close the connection after use using {@link Client.end} to close
+ * open handles.
+ *
+ * @returns A database client, with an active connection.
+ */
+export async function connect(config: Configuration = {}): Promise<Client> {
+    const client = new ClientImpl(config);
+    const info = await client.connect();
+    return Object.assign(client, info);
+}

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -1,6 +1,6 @@
 import { equal, deepEqual, rejects, strictEqual } from 'node:assert';
 import { describe } from 'node:test';
-import { testWithClient } from './helper';
+import { test } from './helper';
 import { Client, ResultIterator, ResultRow } from '../src/index';
 
 type ResultFunction<T> = (result: ResultIterator<T>) => Promise<T[]>;
@@ -36,7 +36,7 @@ async function testIteratorResult<T>(client: Client, f: ResultFunction<T>) {
 }
 
 describe('Result', () => {
-    testWithClient('Default type', async (client) => {
+    test('Default type', async ({ client }) => {
         const result = await client.query(
             'select $1::text as message', ['Hello world!']
         );
@@ -52,7 +52,7 @@ describe('Result', () => {
         equal(mapped.message, 'Hello world!');
     });
 
-    testWithClient('Typed', async (client) => {
+    test('Typed', async ({ client }) => {
         type T = {
             message: string
         };
@@ -67,56 +67,56 @@ describe('Result', () => {
         equal(obj.message, 'Hello world!');
     });
 
-    testWithClient('Parse array containing null', async (client) => {
+    test('Parse array containing null', async ({ client }) => {
         const row = await client.query(
             'select ARRAY[null::text] as a'
         ).one();
         deepEqual(row.a, [null]);
     });
 
-    testWithClient('Format array containing null value', async (client) => {
+    test('Format array containing null value', async ({ client }) => {
         const row = await client.query(
             'select $1::text[] as a', [[null]]
         ).one();
         deepEqual(row.a, [null]);
     });
 
-    testWithClient('Format null-array', async (client) => {
+    test('Format null-array', async ({ client }) => {
         const row = await client.query(
             'select $1::text[] as a', [null]
         ).one();
         equal(row.a, null);
     });
 
-    testWithClient('One', async (client) => {
+    test('One', async ({ client }) => {
         const row = await client.query(
             'select $1::text as message', ['Hello world!']
         ).one();
         equal(row.message, 'Hello world!');
     });
 
-    testWithClient('One (empty query)', async (client) => {
+    test('One (empty query)', async ({ client }) => {
         await rejects(
             client.query('select true where false').one(),
             /empty/
         );
     });
 
-    testWithClient('First (error)', async (client) => {
+    test('First (error)', async ({ client }) => {
         const query = client.query('select does-not-exist');
         return rejects(query.first(), {
             message: 'column "does" does not exist'
         });
     });
 
-    testWithClient('One (error)', async (client) => {
+    test('One (error)', async ({ client }) => {
         const query = client.query('select does-not-exist');
         return rejects(query.one(), {
             message: 'column "does" does not exist'
         });
     });
 
-    testWithClient('Multiple null params', async (client) => {
+    test('Multiple null params', async ({ client }) => {
         const row = await client.query(
             'select $1::text as a, $2::text[] as b, $3::jsonb[] as c',
             [null, null, null]
@@ -126,7 +126,7 @@ describe('Result', () => {
         strictEqual(row.c, null);
     });
 
-    testWithClient('Synchronous iteration', async (client) => {
+    test('Synchronous iteration', async ({ client }) => {
         await testIteratorResult(
             client,
             async (p) => {
@@ -140,7 +140,7 @@ describe('Result', () => {
             });
     });
 
-    testWithClient('Asynchronous iteration', async (client) => {
+    test('Asynchronous iteration', async ({ client }) => {
         await testIteratorResult(
             client,
             async (result) => {
@@ -152,7 +152,7 @@ describe('Result', () => {
             });
     });
 
-    testWithClient('Null typed array', async (client) => {
+    test('Null typed array', async ({ client }) => {
         const row = await client.query('select null::text[] as value').one();
         equal(row.value, null);
     });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { strict as assert } from 'node:assert';
 import { describe } from 'node:test';
-import { testWithClient } from './helper';
+import { test } from './helper';
 
 import {
     DataType,
@@ -33,7 +33,7 @@ function testType<T>(
     excludeTextMode = false,
     bigints?: boolean) {
     const testParam = (format: DataFormat) => {
-        testWithClient('Param', async (client) => {
+        test('Param', async ({ client }) => {
             const text = expected !== null
                 ? getComparisonQueryFor(dataType, expression) + ' where $1 is not null'
                 : 'select $1 is null';
@@ -54,7 +54,7 @@ function testType<T>(
     };
 
     const testValue = (format: DataFormat) => {
-        testWithClient('Value', async (client) => {
+        test('Value', async ({ client }) => {
             const text = 'select ' + expression;
             await client.query({ text, format, bigints }, []).then(
                 (result) => {


### PR DESCRIPTION
This is a breaking change that introduces a `connect` function which is used in place of creating an instance of type `Client`.

```typescript
import { connect } from 'ts-postgres';
const client = await connect();
...
await client.end();
```