### PR TITLE
Make (some more) enums const

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -37,7 +37,7 @@ export const enum SASL {
     SASLResponse = 0x70,
 }
 
-export enum ErrorLevel {
+export const enum ErrorLevel {
     Debug1 = 'DEBUG1',
     Debug2 = 'DEBUG2',
     Debug3 = 'DEBUG3',

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type BufferEncoding = NonNullable<
     Required<Parameters<Buffer['toString']>[0]>
 >;
 
-export enum DataType {
+export const enum DataType {
     Bool = 16,
     Bytea = 17,
     Char = 18,
@@ -129,7 +129,7 @@ export const arrayDataTypeMapping: ReadonlyMap<DataType, DataType> = new Map([
     [DataType.ArrayVarchar, DataType.Varchar],
 ]);
 
-export enum DataFormat {
+export const enum DataFormat {
     Text,
     Binary,
 }


### PR DESCRIPTION
This is related to #100 since `const enum` are completely elided by the compiler.