### PR TITLE
Result row array generic should be 'any', not the record type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 In next release ...
 
--
+- Fixed an issue where the result row array type would use the record generic
+  as the value type instead of `any` which was incorrect.
 
 ## v2.0.2 (2024-04-12)
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -56,7 +56,7 @@ class ResultRowImpl<T> extends Array<any> {
  * the row into an object.
  *
  */
-export type ResultRow<T> = ReadonlyArray<T> &
+export type ResultRow<T> = ReadonlyArray<any> &
     Pick<ResultRowImpl<T>, 'get' | 'reify'>;
 
 /**


### PR DESCRIPTION
Previously, accessing a result row by index would be typed incorrectly as a record type instead of `any`.

(Note that to get a typed value, one would use the `get` or `reify` methods rather than direct array access.)